### PR TITLE
fix(response): factory save endpoints are objects-wrapped on the live…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,12 +31,14 @@
         "csfixer:test": "php-cs-fixer fix -v",
         "phpstan:test": "phpstan analyse --ansi",
         "rector:test": "rector process --ansi",
-        "insights": "phpinsights analyse --ansi -v --no-interaction"
+        "insights": "phpinsights analyse --ansi -v --no-interaction",
+        "test": "vendor/bin/pest"
     },
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "dealerdirect/phpcodesniffer-composer-installer": true
+            "dealerdirect/phpcodesniffer-composer-installer": true,
+            "pestphp/pest-plugin": true
         }
     },
     "minimum-stability": "dev",
@@ -44,6 +46,7 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.64",
         "nunomaduro/phpinsights": "^2.11",
+        "pestphp/pest": "^3.0",
         "phpstan/phpstan": "^1.12",
         "rector/rector": "^1.2"
     }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Test Suite">
+            <directory suffix="Test.php">./tests</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
+</phpunit>

--- a/src/Contracts/HasResultWrapper.php
+++ b/src/Contracts/HasResultWrapper.php
@@ -7,8 +7,11 @@ interface HasResultWrapper
     /**
      * Key under which the payload is wrapped in the response body.
      *
-     * Most sevDesk endpoints wrap their result in an "objects" key, but some
-     * (e.g. the Factory/save* endpoints) return the payload at the top level.
+     * The live sevDesk API wraps virtually all responses in an "objects" key -
+     * including the Factory/save* endpoints, contrary to the official OpenAPI
+     * spec. Only implement this with null for endpoints whose unwrapped
+     * response is verified against the live API (e.g. BookkeepingSystemVersion);
+     * a wrongly assumed null wrapper broke invoice mailing in production once.
      * Return null to receive the full, unwrapped response body.
      */
     public function getResultWrapper(): ?string;

--- a/src/Requests/Basics/BookkeepingSystemVersion.php
+++ b/src/Requests/Basics/BookkeepingSystemVersion.php
@@ -2,6 +2,7 @@
 
 namespace Lacodix\SevdeskSaloon\Requests\Basics;
 
+use Lacodix\SevdeskSaloon\Contracts\HasResultWrapper;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
 
@@ -10,7 +11,7 @@ use Saloon\Http\Request;
  *
  * To check if you already received the update to version 2.0 you can use this endpoint.
  */
-class BookkeepingSystemVersion extends Request
+class BookkeepingSystemVersion extends Request implements HasResultWrapper
 {
     protected Method $method = Method::GET;
 
@@ -21,5 +22,12 @@ class BookkeepingSystemVersion extends Request
     public function resolveEndpoint(): string
     {
         return '/Tools/bookkeepingSystemVersion';
+    }
+
+    public function getResultWrapper(): ?string
+    {
+        // /Tools/bookkeepingSystemVersion returns its payload at the top level
+        // ({ "version": ... }) without an "objects" wrapper.
+        return null;
     }
 }

--- a/src/Requests/CreditNote/CreateCreditNote.php
+++ b/src/Requests/CreditNote/CreateCreditNote.php
@@ -2,7 +2,6 @@
 
 namespace Lacodix\SevdeskSaloon\Requests\CreditNote;
 
-use Lacodix\SevdeskSaloon\Contracts\HasResultWrapper;
 use Lacodix\SevdeskSaloon\Enums\Countries;
 use Lacodix\SevdeskSaloon\Enums\CreditNoteStatus;
 use Lacodix\SevdeskSaloon\Traits\HasPositions;
@@ -38,7 +37,7 @@ use Saloon\Traits\Body\HasJsonBody;
  * information left, is that the order of the last five attributes always needs to be kept.<br> You
  * will also always need to provide all of them, as otherwise the request won't work properly.
  */
-class CreateCreditNote extends Request implements HasBody, HasResultWrapper
+class CreateCreditNote extends Request implements HasBody
 {
     use HasJsonBody;
     use HasPositions;
@@ -119,12 +118,5 @@ class CreateCreditNote extends Request implements HasBody, HasResultWrapper
         $this->sevdeskConfig = $config;
 
         return $this;
-    }
-
-    public function getResultWrapper(): ?string
-    {
-        // The Factory/saveCreditNote endpoint returns its payload at the top level
-        // without an "objects" wrapper.
-        return null;
     }
 }

--- a/src/Requests/Invoice/CreateInvoice.php
+++ b/src/Requests/Invoice/CreateInvoice.php
@@ -2,7 +2,6 @@
 
 namespace Lacodix\SevdeskSaloon\Requests\Invoice;
 
-use Lacodix\SevdeskSaloon\Contracts\HasResultWrapper;
 use Lacodix\SevdeskSaloon\Enums\Countries;
 use Lacodix\SevdeskSaloon\Enums\InvoiceStatus;
 use Lacodix\SevdeskSaloon\Traits\HasPositions;
@@ -53,7 +52,7 @@ use Saloon\Traits\Body\HasJsonBody;
  * being later than the <b>invoiceDate</b>.<br> To do that you will need to create a so called
  * <b>Abschlagsrechnung</b> by setting the <b>invoiceType</b> parameter to <b>AR</b>.
  */
-class CreateInvoice extends Request implements HasBody, HasResultWrapper
+class CreateInvoice extends Request implements HasBody
 {
     use HasJsonBody;
     use HasPositions;
@@ -143,12 +142,5 @@ class CreateInvoice extends Request implements HasBody, HasResultWrapper
         $this->sevdeskConfig = $config;
 
         return $this;
-    }
-
-    public function getResultWrapper(): ?string
-    {
-        // The Factory/saveInvoice endpoint returns its payload at the top level
-        // ({ "invoice": {...}, "invoicePos": [...] }) without an "objects" wrapper.
-        return null;
     }
 }

--- a/src/Requests/Order/CreateOrder.php
+++ b/src/Requests/Order/CreateOrder.php
@@ -2,7 +2,6 @@
 
 namespace Lacodix\SevdeskSaloon\Requests\Order;
 
-use Lacodix\SevdeskSaloon\Contracts\HasResultWrapper;
 use Lacodix\SevdeskSaloon\Enums\Countries;
 use Lacodix\SevdeskSaloon\Enums\OrderStatus;
 use Lacodix\SevdeskSaloon\Traits\HasPositions;
@@ -16,7 +15,7 @@ use Saloon\Traits\Body\HasJsonBody;
  *
  * Creates an order to which positions can be added later.
  */
-class CreateOrder extends Request implements HasBody, HasResultWrapper
+class CreateOrder extends Request implements HasBody
 {
     use HasJsonBody;
     use HasPositions;
@@ -99,12 +98,5 @@ class CreateOrder extends Request implements HasBody, HasResultWrapper
         $this->sevdeskConfig = $config;
 
         return $this;
-    }
-
-    public function getResultWrapper(): ?string
-    {
-        // The Factory/saveOrder endpoint returns its payload at the top level
-        // without an "objects" wrapper.
-        return null;
     }
 }

--- a/src/Requests/Voucher/CreateVoucher.php
+++ b/src/Requests/Voucher/CreateVoucher.php
@@ -2,7 +2,6 @@
 
 namespace Lacodix\SevdeskSaloon\Requests\Voucher;
 
-use Lacodix\SevdeskSaloon\Contracts\HasResultWrapper;
 use Saloon\Contracts\Body\HasBody;
 use Saloon\Enums\Method;
 use Saloon\Http\Request;
@@ -30,7 +29,7 @@ use Saloon\Traits\Body\HasJsonBody;
  * vouchers. If you have to, you can downgrade the status by calling resetToOpen (from paid) and
  * resetToDraft (from open).
  */
-class CreateVoucher extends Request implements HasBody, HasResultWrapper
+class CreateVoucher extends Request implements HasBody
 {
     use HasJsonBody;
 
@@ -49,12 +48,5 @@ class CreateVoucher extends Request implements HasBody, HasResultWrapper
     public function defaultBody(): array
     {
         return $this->data;
-    }
-
-    public function getResultWrapper(): ?string
-    {
-        // The Factory/saveVoucher endpoint returns its payload at the top level
-        // without an "objects" wrapper.
-        return null;
     }
 }

--- a/src/SevdeskSaloon.php
+++ b/src/SevdeskSaloon.php
@@ -63,9 +63,14 @@ class SevdeskSaloon extends Connector
             ? $request->getResultWrapper()
             : 'objects';
 
+        $json = $response->json();
+
+        // The sevDesk OpenAPI spec and the live API disagree for some endpoints
+        // on whether the payload is wrapped; fall back to the full body when
+        // the expected wrapper key is missing.
         return $wrapper === null
-            ? $response->json()
-            : $response->json()[$wrapper];
+            ? $json
+            : ($json[$wrapper] ?? $json);
     }
 
     public function resolveBaseUrl(): string

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Lacodix\SevdeskSaloon\SevdeskSaloon;
+
+function connector(): SevdeskSaloon
+{
+    return new SevdeskSaloon('test-token', [
+        'sevUserId' => 1,
+        'taxRate' => 19,
+        'taxText' => 'VAT 19%',
+        'taxType' => 'default',
+        'taxRule' => 1,
+        'currency' => 'EUR',
+        'invoiceType' => 'RE',
+    ]);
+}

--- a/tests/Unit/SevSendTest.php
+++ b/tests/Unit/SevSendTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use Lacodix\SevdeskSaloon\Requests\Basics\BookkeepingSystemVersion;
+use Lacodix\SevdeskSaloon\Requests\Invoice\CreateInvoice;
+use Lacodix\SevdeskSaloon\Requests\Invoice\GetInvoices;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+it('strips the objects wrapper by default', function () {
+    $mockClient = new MockClient([
+        GetInvoices::class => MockResponse::make(['objects' => [['id' => '1']]]),
+    ]);
+
+    $result = connector()->sevSend(new GetInvoices(), $mockClient);
+
+    expect($result)->toBe([['id' => '1']]);
+});
+
+it('strips the objects wrapper from factory create responses', function () {
+    // Regression: the live API wraps Factory/save* payloads in "objects",
+    // contrary to the OpenAPI spec (v0.16.0 broke this with a null wrapper).
+    $mockClient = new MockClient([
+        CreateInvoice::class => MockResponse::make([
+            'objects' => [
+                'invoice' => ['id' => '80356663', 'invoiceNumber' => 'RE-241002'],
+                'invoicePos' => [],
+            ],
+        ]),
+    ]);
+
+    $request = new CreateInvoice(1, [['name' => 'Base Fee', 'price' => 10.0]], []);
+    $result = connector()->sevSend($request, $mockClient);
+
+    expect($result['invoice']['id'])->toBe('80356663')
+        ->and($result['invoice']['invoiceNumber'])->toBe('RE-241002');
+});
+
+it('falls back to the full body when the wrapper key is missing', function () {
+    $mockClient = new MockClient([
+        CreateInvoice::class => MockResponse::make([
+            'invoice' => ['id' => '80356663'],
+            'invoicePos' => [],
+        ]),
+    ]);
+
+    $request = new CreateInvoice(1, [['name' => 'Base Fee', 'price' => 10.0]], []);
+    $result = connector()->sevSend($request, $mockClient);
+
+    expect($result['invoice']['id'])->toBe('80356663');
+});
+
+it('returns the full body for requests declaring a null wrapper', function () {
+    $mockClient = new MockClient([
+        BookkeepingSystemVersion::class => MockResponse::make(['version' => '2.0']),
+    ]);
+
+    $result = connector()->sevSend(new BookkeepingSystemVersion(), $mockClient);
+
+    expect($result)->toBe(['version' => '2.0']);
+});
+
+it('throws on unsuccessful responses', function () {
+    $mockClient = new MockClient([
+        GetInvoices::class => MockResponse::make(['error' => 'nope'], 500),
+    ]);
+
+    connector()->sevSend(new GetInvoices(), $mockClient);
+})->throws(Exception::class);


### PR DESCRIPTION
… API

The v0.16.0 null result-wrapper on CreateInvoice/CreateOrder/ CreateCreditNote/CreateVoucher followed the OpenAPI spec, but the live API wraps these payloads in "objects" like everything else - this broke invoice mailing in production (membergy, 2026-07-01).

- drop the wrong null overrides, factory requests use the default again
- sevSend() falls back to the full body when the wrapper key is missing
- BookkeepingSystemVersion declares the (verified) null wrapper instead
- add a Pest suite covering all wrapper shapes (composer test)